### PR TITLE
fix multiple .r in id

### DIFF
--- a/contrib/server-side/fsfsfixer/fixer/find_good_id.py
+++ b/contrib/server-side/fsfsfixer/fixer/find_good_id.py
@@ -31,7 +31,8 @@ def parse_id(id):
      "NODEREV/OFFSET", and NODEREV is of the form "SOMETHING.rREV".
   """
   noderev, offset = id.split('/')
-  _, rev = noderev.split('.r')
+  tmp1, tmp2, tmprev = noderev.split('.')
+  _, rev = tmprev.split('r')
   return noderev, rev, offset
 
 def rev_file_path(repo_dir, rev):


### PR DESCRIPTION
example : l-4129.s-14277.r14469 
run err ValueError: too many values to unpack
