### PR TITLE
SWIG: Remove -classic Python option

### DIFF
--- a/build.conf
+++ b/build.conf
@@ -101,7 +101,7 @@ test-scripts =
 
 bdb-test-scripts =
 
-swig-python-opts = $(SWIG_FEATURES) -python $(SWIG_PY_FEATURES) -classic
+swig-python-opts = $(SWIG_FEATURES) -python $(SWIG_PY_FEATURES)
 swig-perl-opts = $(SWIG_FEATURES) -perl $(SWIG_PL_FEATURES) -nopm -noproxy
 swig-ruby-opts = $(SWIG_FEATURES) -ruby $(SWIG_RB_FEATURES)
 swig-languages = python perl ruby


### PR DESCRIPTION
It has been removed in swig 4.0, only needed to support python <2.2:
https://github.com/swig/swig/commit/728b8955bd50d79168e121f834295ef30fcdc89e