### PR TITLE
build/ac-macros/macosx.m4: workaround AC_RUN_IFELSE

### DIFF
--- a/build/ac-macros/macosx.m4
+++ b/build/ac-macros/macosx.m4
@@ -38,7 +38,7 @@ AC_DEFUN(SVN_LIB_MACHO_ITERATE,
     AC_MSG_RESULT([yes])
   ],[
     AC_MSG_RESULT([no])
-  ])
+  ],[:])
 ])
 
 dnl SVN_LIB_MACOS_PLIST


### PR DESCRIPTION
The SVN_LIB_MACHO_ITERATE macro contains an AC_RUN_IFELSE test that
doesn't work when cross-compiling. However, this macro is related to
testing Mac OS X APIs, so in the context of Buildroot, we don't care,
and the test program is not even going to build. So we simply
workaround this by turning the test into an AC_COMPILE_IFELSE.

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
[Retrieved from:
https://git.buildroot.net/buildroot/tree/package/subversion/0002-workaround-ac-run-ifelse.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>