### PR TITLE
docs: fix simple typo, tolerting -> tolerating

### DIFF
--- a/subversion/tests/cmdline/merge_reintegrate_tests.py
+++ b/subversion/tests/cmdline/merge_reintegrate_tests.py
@@ -1508,7 +1508,7 @@ def reintegrate_with_subtree_mergeinfo(sbox):
     # is all quite ugly as the intersection or multiple known issues
     # is likely to be.  However, given that none of this mergeinfo is
     # particularly harmful and that this test is *not* about issues #3669
-    # or #4309, we are tolerting it.
+    # or #4309, we are tolerating it.
     'D/gamma_moved' : Item(
       "Even newer content", props={SVN_PROP_MERGEINFO :
                                    '/A/D/gamma_moved:2-7,9-12\n'


### PR DESCRIPTION
There is a small typo in subversion/tests/cmdline/merge_reintegrate_tests.py.

Should read `tolerating` rather than `tolerting`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md