### PR TITLE
Fix ra-test execution of svnserve in some build environments.

### DIFF
--- a/.github/workflows/autoconf.yml
+++ b/.github/workflows/autoconf.yml
@@ -24,6 +24,8 @@ name: autoconf
 on:
   push:
     branches: ["*"]
+  pull_request:
+    branches: ["*"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -24,6 +24,8 @@ name: CMake
 on:
   push:
     branches: ["*"]
+  pull_request:
+    branches: ["*"]
 
 concurrency:
   group: ${{ github.ref }}

--- a/subversion/tests/libsvn_ra/ra-test.c
+++ b/subversion/tests/libsvn_ra/ra-test.c
@@ -277,7 +277,7 @@ open_tunnel(svn_stream_t **request, svn_stream_t **response,
   if (status == APR_SUCCESS)
     status = apr_procattr_io_set(attr, 1, 1, 0);
   if (status == APR_SUCCESS)
-    status = apr_procattr_cmdtype_set(attr, APR_PROGRAM);
+    status = apr_procattr_cmdtype_set(attr, APR_PROGRAM_ENV);
   proc = apr_palloc(pool, sizeof(*proc));
   if (status == APR_SUCCESS)
     status = apr_proc_create(proc,


### PR DESCRIPTION
```
Fix ra-test execution of svnserve in some build environments.

* subversion/tests/libsvn_ra/ra-test.c
  (open_tunnel): Execute the wrapper with APR_PROGRAM_ENV rather than
  APR_PROGRAM, so the build environment is inherited. The "svnserve"
  executed here may be a libtool wrapper script which can in some cases
  depend on the build environment to execute correctly.
```