### PR TITLE
Display the original name of component.

### DIFF
--- a/subversion/svn/diff-cmd.c
+++ b/subversion/svn/diff-cmd.c
@@ -174,9 +174,9 @@ summarize_regular(const svn_client_diff_summarize_t *summary,
   if (b->ignore_properties)
     prop_change = ' ';
 
-  SVN_ERR(svn_cmdline_printf(pool, "%c%c      %s\n",
+  SVN_ERR(svn_cmdline_printf(pool, "%c%c      %s '%s'\n",
                              kind_to_char(summary->summarize_kind),
-                             prop_change, path));
+                             prop_change, path, summary->path));
 
   return svn_cmdline_fflush(stdout);
 }


### PR DESCRIPTION
  * In the old days, the '--summerize' option could show the component's original's name in the svn URI because it's not escaped. After the commit 3dbf4fb0 the component's name would be escaped. So it's not easy to tell which file was modified based on the svn URI format. This small patch appends the original name to the URI result so that the user could read the file name after displaying the svn URI.