### PR TITLE
mod_dav_svn: Use mod_dav's DAVBasePath setting

### DIFF
--- a/.github/workflows/autoconf.yml
+++ b/.github/workflows/autoconf.yml
@@ -38,9 +38,16 @@ jobs:
       matrix:
         check-target: [check, davautocheck]
         os: [ubuntu-latest, ubuntu-22.04-arm]
+        httpd: [system, trunk, 2.4.x]
+        # Don't
+        exclude:
+          - check-target: check
+            httpd: trunk
+          - check-target: check
+            httpd: 2.4.x
 
     runs-on: ${{ matrix.os }}
-    name: ${{ matrix.os }}, target ${{ matrix.check-target }}
+    name: ${{ matrix.os }}, target ${{ matrix.check-target }}, ${{ matrix.httpd }} httpd
 
     steps:
       - name: Install dependencies (Linux, apt-get)
@@ -58,7 +65,7 @@ jobs:
           libsqlite3-dev
           liblz4-dev
           libutf8proc-dev
-          apache2-dev
+          ${{ matrix.httpd == 'system' && 'apache2-dev' || '' }}
           libsecret-1-dev
 
       - name: Use LF for Git checkout
@@ -66,13 +73,24 @@ jobs:
           git config --global core.autocrlf false
           git config --global core.eol lf
 
+      - name: Install Apache httpd
+        run: |
+          test "${{ matrix.httpd }}" != 'system' || exit 0
+          git clone -q --depth=1 -b ${{ matrix.httpd }} https://github.com/apache/httpd
+          cd httpd
+          ./buildconf --with-apr=/usr/bin/apr-1-config
+          ./configure --prefix=$HOME/root/httpd --enable-mpms-shared=event --enable-mods-shared=most --enable-dav
+          make -j
+          make install
       - uses: actions/checkout@v4
 
       - name: autogen
         run: ./autogen.sh
 
       - name: Configure
-        run: ./configure --enable-maintainer-mode
+        run: |
+          ./configure --enable-maintainer-mode \
+              --with-apxs=${{ matrix.httpd == 'system' && '/usr/bin/apxs' || '${HOME}/root/httpd/bin/apxs' }}
 
       - name: Build (make)
         run: make -j
@@ -80,12 +98,14 @@ jobs:
       - name: Run tests
         run: make ${{matrix.check-target}} PARALLEL=16 APACHE_MPM=event
 
-      - name: Archive test log
+      - name: Archive test logs
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: tests-${{matrix.os}}-${{matrix.check-target}}.log
-          path: tests.log
+          name: tests-${{matrix.os}}-${{matrix.check-target}}-${{matrix.httpd}}
+          path: |
+            tests.log
+            subversion/tests/cmdline/httpd**/*_log
 
       - name: Install (make install)
         run: sudo make install

--- a/subversion/mod_dav_svn/mod_dav_svn.c
+++ b/subversion/mod_dav_svn/mod_dav_svn.c
@@ -781,6 +781,15 @@ const char *
 dav_svn__get_root_dir(request_rec *r)
 {
   dir_conf_t *conf;
+#if AP_MODULE_MAGIC_AT_LEAST(20120211, 139)
+  const char *base;
+
+  /* Inherit the root path from mod_dav's DavBasePath iff configured
+     where e.g. LocationMatch is used for the repos. */
+  base = dav_get_base_path(r);
+  if (base)
+    return base;
+#endif
 
   conf = ap_get_module_config(r->per_dir_config, &dav_svn_module);
   return conf->root_dir;
@@ -1225,7 +1234,7 @@ static int dav_svn__translate_name(request_rec *r)
   else
     {
       /* Retrieve path to repo and within repo for the request */
-      dav_error *err = dav_svn_split_uri(r, r->uri, conf->root_dir,
+      dav_error *err = dav_svn_split_uri(r, r->uri, dav_svn__get_root_dir(r),
                                          &ignore_cleaned_uri,
                                          &ignore_had_slash, &repos_basename,
                                          &ignore_relative_path, &repos_path);


### PR DESCRIPTION
```
mod_dav_svn: Use mod_dav's DAVBasePath setting to determine the
repository root path, allowing SVN to be configured via LocationMatch like:

 <LocationMatch ^/repos/svn(.*)>
    DAV svn
    SVNParentPath /srv/repos
    DAVBasePath /repos
 </LocationMatch>

by mapping URL path "/repos/svnfoo" to the filesystem path of "/srv/repos/svnfoo". This partially addresses issues like SVN-4790 (with minimal added complexity), though does not provide as much flexibility as discussed in SVN-2679.

* subversion/mod_dav_svn/mod_dav_svn.c (dav_svn__get_root_dir): Retrieve and return the setting from DavBasePath via dav_get_base_path() where that API is available and DavBasePath is configured. (dav_svn__translate_name): Use dav_svn__get_root_dir() to determine the repos root for the same reason.
```

Note this mod_dav API is only present in httpd trunk (currently).