### PR TITLE
Bug: dict.copy() always returns None

### DIFF
--- a/tools/hook-scripts/mailer/mailer.py
+++ b/tools/hook-scripts/mailer/mailer.py
@@ -1401,7 +1401,9 @@ class Config:
             # Extract key/value pairs from the regex match of this
             # repository, and merge them into the default params.
             # Make sure to copy() to avoid mutation of the argument.
-            return defaults.copy().update(match.groupdict())
+            merged_defaults = defaults.copy()
+            merged_defaults.update(match.groupdict())
+            return merged_defaults
 
         # There are no repository-specific key/value params, to add.
         return defaults


### PR DESCRIPTION
We need the merged defaults copy returned to us, so the old return is instead split into three commands:

- copy `defaults`
- update the copy with `match.groupdict()`
- return the updated copy